### PR TITLE
Fix the code for the Chilean peso

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -61,6 +61,8 @@ const inclusionsOrFixes = [
   { countryCode: 'KR', currencyCode: 'KRW' },
   // According to Wikipedia, Switzerland uses 'CHF'. Thanks @betabong for pointing it out.
   { countryCode: 'CH', currencyCode: 'CHF' },
+  // According to Wikipedia, CLF is a non-circulating currency for Chile, the Chilean peso is CLP.
+  { countryCode: 'CL', currencyCode: 'CLP' },
 ];
 
 let inclusions = 0;

--- a/index.ts
+++ b/index.ts
@@ -43,7 +43,7 @@ export default {
   CH: 'CHF',
   CI: 'XOF',
   CK: 'NZD',
-  CL: 'CLF',
+  CL: 'CLP',
   CM: 'XAF',
   CN: 'CNY',
   CO: 'COP',


### PR DESCRIPTION
Hi Thiago,

I'm working on an app that handles currencies for a few Latin American
countries, and realized the currency code for Chile is wrong.

According to Wikipedia, CLF is a non-circulating currency for Chile, the
Chilean peso is CLP.

- CLP: https://en.wikipedia.org/wiki/Chilean_peso
- CLF: https://en.wikipedia.org/wiki/Unidad_de_Fomento