### PR TITLE
Croatia (HR) moves from HRK -> EUR on 1 January 2023

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -65,6 +65,8 @@ const inclusionsOrFixes = [
   { countryCode: 'CL', currencyCode: 'CLP' },
   // According to Wikipedia, Uruguay uses 'UYU'. Thanks @marneborn for pointing it out.
   { countryCode: 'UY', currencyCode: 'UYU' },
+  // According to Wikipedia and Stripe, Crotia moved from HRK (Kuna) to the EUR (Euro) on January 1, 2023 (@xaphod)
+  { countryCode: 'HR', currencyCode: 'EUR' },
 ];
 
 let inclusions = 0;

--- a/index.ts
+++ b/index.ts
@@ -92,7 +92,7 @@ export default {
   GY: 'GYD',
   HK: 'HKD',
   HN: 'HNL',
-  HR: 'HRK',
+  HR: 'EUR',
   HT: 'HTG',
   HU: 'HUF',
   ID: 'IDR',


### PR DESCRIPTION
Thank you for this library.
I understand Croatia has just changed its currency from HRK to EUR on 1 January 2023.

Sources: 
- https://support.stripe.com/questions/croatian-kuna-%28hrk%29-currency-transition-to-euro-%28eur%29
- https://en.wikipedia.org/wiki/Croatian_kuna