### PR TITLE
fix: use `WST` currency code for Samoa

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -243,7 +243,7 @@ const countryToCurrency = {
   VN: 'VND',
   VU: 'VUV',
   WF: 'XPF',
-  WS: 'USD',
+  WS: 'WST',
   YE: 'YER',
   YT: 'EUR',
   ZA: 'ZAR',


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Samoa

According to Wikipedia, the Tālā (symbol: WST) is the current currency in Samoa.
