### PR TITLE
fix: update Hungary's currency from EUR to HUF

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -97,7 +97,7 @@ const countryToCurrency = {
   HK: 'HKD',
   HM: 'AUD',
   HN: 'HNL',
-  HR: 'EUR',
+  HR: 'HUF',
   HT: 'HTG',
   HU: 'HUF',
   ID: 'IDR',


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Hungary

"While the Hungarian government has been planning since 2003 to replace the Hungarian forint with the euro, as of 2023, there is no target date and the forint is not part of the European Exchange Rate Mechanism." https://en.wikipedia.org/wiki/Hungary_and_the_euro