### PR TITLE
fix: use CUP for Cuba

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -50,7 +50,7 @@ const countryToCurrency = {
   CN: 'CNY',
   CO: 'COP',
   CR: 'CRC',
-  CU: 'CUC',
+  CU: 'CUP',
   CV: 'CVE',
   CW: 'ANG',
   CX: 'AUD',


### PR DESCRIPTION
"On January 1, 2021, Cuba's dual currency system was formally ended, and the convertible Cuban peso (CUC) was phased out, leaving the Cuban peso (CUP) as the country's sole currency unit."

https://en.wikipedia.org/wiki/Cuba