### PR TITLE
Add index type for TypeScript

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -179,8 +179,15 @@ const sorted = Object.keys( result )
 // Generate file
 //
 
+const typescriptType = `
+type CountryToCurrencyMap = {
+  [key: string]: string;
+}\n
+`;
+
 const content = '// This is a generated file - please do not modify it\n' +
-  'const countryToCurrency = ' +
+  typescriptType +
+  'const countryToCurrency: CountryToCurrencyMap = ' +
   JSON.stringify( sorted, null, 2 )
     .replace(/"([A-Z]{2})":/g, '$1:')
     .replace(/"/g, "'") +

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,10 @@
 // This is a generated file - please do not modify it
-const countryToCurrency = {
+
+type CountryToCurrencyMap = {
+  [key: string]: string;
+}
+
+const countryToCurrency: CountryToCurrencyMap = {
   AD: 'EUR',
   AE: 'AED',
   AF: 'AFN',


### PR DESCRIPTION
This adds an Index type to properly work in Typescript to find an element by the Country Code string.


Issue with the typescript compiler without it:
```
Type error: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{ readonly AD: "EUR"; readonly AE: "AED"; readonly AF: "AFN"; readonly AG: "XCD"; readonly AI: "XCD"; readonly AL: "ALL"; readonly AM: "AMD"; readonly AN: "ANG"; readonly AO: "AOA"; readonly AQ: "USD"; ... 239 more ...; readonly ZW: "ZWL"; }'.
  No index signature with a parameter of type 'string' was found on type '{ readonly AD: "EUR"; readonly AE: "AED"; readonly AF: "AFN"; readonly AG: "XCD"; readonly AI: "XCD"; readonly AL: "ALL"; readonly AM: "AMD"; readonly AN: "ANG"; readonly AO: "AOA"; readonly AQ: "USD"; ... 239 more ...; readonly ZW: "ZWL"; }'.
``` 