### PR TITLE
Change currency code for BG from BGN to EUR

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -22,7 +22,7 @@ const countryToCurrency = {
   BD: 'BDT',
   BE: 'EUR',
   BF: 'XOF',
-  BG: 'BGN',
+  BG: 'EUR',
   BH: 'BHD',
   BI: 'BIF',
   BJ: 'XOF',


### PR DESCRIPTION
On 1 January 2026, Bulgaria joined the Eurozone.

https://www.ecb.europa.eu/euro/changeover/bulgaria/html/index.en.html